### PR TITLE
WIP - Use one feed for all years

### DIFF
--- a/src/Afsy/Bundle/FrontBundle/Controller/AventController.php
+++ b/src/Afsy/Bundle/FrontBundle/Controller/AventController.php
@@ -36,9 +36,19 @@ class AventController extends Controller
         ));
     }
 
-    public function feedAction($year)
+    public function feedAction($year = null)
     {
-        return $this->render('AfsyFrontBundle:Avent:year_'.$year.'.atom.twig', array(
+        // keep BC with previous feed
+        if (null !== $year) {
+            return $this->redirect($this->generateUrl('avent_feed_atom'));
+        }
+
+        // just display the last year in the feed
+        $years = array_keys($this->slugs);
+        krsort($years);
+        $year = current($years);
+
+        return $this->render('AfsyFrontBundle:Avent:feed.atom.twig', array(
             'year' => $year,
             'days' => $this->loadYearData($year)
         ));

--- a/src/Afsy/Bundle/FrontBundle/Resources/config/routing.yml
+++ b/src/Afsy/Bundle/FrontBundle/Resources/config/routing.yml
@@ -22,11 +22,16 @@ blog_show_tag:
     pattern: /blog/tag/{name}
     defaults: { _controller: AfsyFrontBundle:Blog:showTag }
 
+avent_feed_atom:
+    pattern: /avent/feed.atom
+    defaults: { _controller: AfsyFrontBundle:Avent:feed, _format: xml }
+
 avent:
     pattern: /avent/{year}
     defaults: { _controller: AfsyFrontBundle:Avent:index, year: null }
 
-avent_feed_atom:
+# for BC
+avent_feed_atom_year:
     pattern: /avent/{year}/feed.atom
     defaults: { _controller: AfsyFrontBundle:Avent:feed, _format: xml }
 

--- a/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/feed.atom.twig
+++ b/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/feed.atom.twig
@@ -2,7 +2,7 @@
     <id>{{ url('avent', {year: year}) }}</id>
     <title>Calendrier de l'avent de l'Afsy {{ year }}</title>
     <link type="text/html" rel="alternate" href="{{ url('avent', {year: year}) }}"/>
-    <link type="application/rss+xml" rel="self" href="{{ url('avent_feed_atom', {year: year}) }}"/>
+    <link type="application/atom+xml" rel="self" href="{{ url('avent_feed_atom') }}"/>
     <updated>{{ 'now'|date('c') }}</updated>
 
     {% set day = 0 %}

--- a/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/year.html.twig
+++ b/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/year.html.twig
@@ -1,10 +1,5 @@
 {% extends 'AfsyFrontBundle::layout.html.twig' %}
 
-{% block atom_feed %}
-    <link rel="alternate" type="application/atom+xml" title="AFSY - tous les articles" href="{{ url('feed_atom') }}"/>
-    <link rel="alternate" type="application/atom+xml" title="AFSY - calendrier de l'avent {{ year }}" href="{{ url('avent_feed_atom', { year: year}) }}"/>
-{% endblock %}
-
 {% set header_expanded = false %}
 
 {% block page_title %}

--- a/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/year_2013.atom.twig
+++ b/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/year_2013.atom.twig
@@ -1,3 +1,0 @@
-{% extends 'AfsyFrontBundle:Avent:year.atom.twig' %}
-
-{% set year = 2013 %}

--- a/src/Afsy/Bundle/FrontBundle/Resources/views/layout.html.twig
+++ b/src/Afsy/Bundle/FrontBundle/Resources/views/layout.html.twig
@@ -27,9 +27,8 @@
             <link href="{{ asset("css/avent.css") }}" rel="stylesheet"/>
         {% endblock %}
 
-        {% block atom_feed %}
-            <link rel="alternate" type="application/atom+xml" title="AFSY - tous les articles" href="{{ url('feed_atom') }}"/>
-        {% endblock %}
+        <link rel="alternate" type="application/atom+xml" title="AFSY - tous les articles" href="{{ url('feed_atom') }}"/>
+        <link rel="alternate" type="application/atom+xml" title="AFSY - calendrier de l'avent" href="{{ url('avent_feed_atom') }}"/>
     </head>
     <body>
 


### PR DESCRIPTION
J'ai pensé que ça serait plus intéressant d'avoir un seul flux rss pour tous les (potentiels) calendriers de l'avent qu'on fera plutôt que d'en avoir un pour chaque.

Ca évitera aux personnes d'avoir à changer leur flux. Et du coup, le flux pour le calendrier de l'avent est disponible sur la home du site aussi (comme l'année n'est plus un paramètre).
J'ai quand même gardé l'ancienne url, dans le cas où des personnes se seraient abonnés depuis ce matin.

Qu'en pensez-vous ?
