### PR TITLE
sfPropel15Plugin n'est plus supporté, par contre sfPropelORMPlugin est bien maintenu

### DIFF
--- a/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/day_2013_03.html.twig
+++ b/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/day_2013_03.html.twig
@@ -420,7 +420,7 @@ class ListController extends Controller
     <abbr title="Standard Query Langage" lang="en">SQL</abbr> un peu spécifique
     qui permet de mieux visualiser les index que nous avons utilisé et de mieux
     les comprendre. Ce dernier est inclus dans la barre de débogage de Symfony2,
-    mais aussi dans celle de symfony1 avec le <code>sfPropel15Plugin</code>.
+    mais aussi dans celle de symfony1 avec le <code>sfPropelORMPlugin</code>.
 </p>
 
 <p>


### PR DESCRIPTION
http://www.symfony-project.org/plugins/sfPropel15Plugin
