### PR TITLE
fix atom feed for avent 2017

### DIFF
--- a/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/year_2017.atom.twig
+++ b/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/year_2017.atom.twig
@@ -1,0 +1,3 @@
+{% extends 'AfsyFrontBundle:Avent:year.atom.twig' %}
+
+{% set year = 2017 %}


### PR DESCRIPTION
This URL http://www.afsy.fr/avent/2017/feed.atom returns a 500.

This PR tries to fix this issue.