### PR TITLE
Improve rendering of the workflow article

### DIFF
--- a/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/day_2017_19.html.twig
+++ b/src/Afsy/Bundle/FrontBundle/Resources/views/Avent/day_2017_19.html.twig
@@ -15,7 +15,7 @@
 
     <p> Introduit avec Symfony 3.2, le <a href="https://symfony.com/doc/master/components/workflow.html" target="_blank">composant Workflow</a> permet de gérer simplement les différents états et transitions au sein de vos objets. Découvrons ensemble l’utilisation de ce composant avec un exemple simple de l’e-commerce et bien connu de tous : le colis. </p>
 
-    <p>Un colis ne peut avoir qu’un état à la fois. Son état peut prendre les valeurs « <em lang="en">new</em> », « <em lang="en">preparing</em> », « <em lang="en">prepared</em> », « <em lang="en">shipped</em> », « <em lang="en">delivered</em> », « <em lang="en">returned</em> », «<em lang="en">lost</em>».</p>
+    <p>Un colis ne peut avoir qu’un état à la fois. Son état peut prendre les valeurs «&nbsp;<em lang="en">new</em>&nbsp;», «&nbsp;<em lang="en">preparing</em>&nbsp;», «&nbsp;<em lang="en">prepared</em>&nbsp;», «&nbsp;<em lang="en">shipped</em>&nbsp;», «&nbsp;<em lang="en">delivered</em>&nbsp;», «&nbsp;<em lang="en">returned</em>&nbsp;», «&nbsp;<em lang="en">lost</em>&nbsp;».</p>
 
     <p>Grâce au composant Workflow, nous pouvons très simplement définir ces différents états et les transitions entre chacun d’entre eux. Pour cela, éditons le fichier <em>config/packages/workflows.yml</em> ainsi :</p>
 


### PR DESCRIPTION
The goal is to avoid this rendering:

![afsy_workflow](https://user-images.githubusercontent.com/439401/34378148-d321955c-eaf4-11e7-87fc-77e4b2588b90.png)

/cc @nayluge 
