### PR TITLE
Added better CSS for Markdown

### DIFF
--- a/assets/css/avent.css
+++ b/assets/css/avent.css
@@ -8,3 +8,24 @@
 #avent-2019 .calendar_date p span {
     background: #ad0000;
 }
+
+#avent-2019 .avent-article {
+    padding-left: .3rem;
+    padding-right: .3rem;
+}
+
+#avent-2019 .avent-article p,
+#avent-2019 .avent-article li {
+    text-align: justify;
+}
+
+#avent-2019 .avent-article p img {
+    margin: 2em auto 0;
+}
+
+#avent-2019 .avent-article .avent-image-legend {
+    margin: .5em auto 2em;
+    text-align: center;
+    font-style: italic;
+    color: #999;
+}

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -133,6 +133,27 @@ img {
     src: url('../fonts/Muli-Regular-webfont.ttf') format('truetype'), url('../fonts/Muli-Regular-webfont.ttf') format('opentype'), url('../fonts/Muli-Regular-webfont.eot') format('embedded-opentype'), url('../fonts/Muli-Regular-webfont.svg') format('svg')
 }
 
+@font-face {
+    font-family: "Muli";
+    src: url('../fonts/Muli-Italic-webfont.ttf') format('truetype'), url('../fonts/Muli-Italic-webfont.ttf') format('opentype'), url('../fonts/Muli-Italic-webfont.eot') format('embedded-opentype'), url('../fonts/Muli-Italic-webfont.svg') format('svg');
+    font-style: italic;
+}
+
+@font-face {
+    font-family: "Muli";
+    src: url('../fonts/Muli-Light-webfont.ttf') format('truetype'), url('../fonts/Muli-Light-webfont.ttf') format('opentype'), url('../fonts/Muli-Light-webfont.eot') format('embedded-opentype'), url('../fonts/Muli-Light-webfont.svg') format('svg');
+    font-style: normal;
+    font-weight: 200;
+}
+
+@font-face {
+    font-family: "Muli";
+    src: url('../fonts/Muli-LightItalic-webfont.ttf') format('truetype'), url('../fonts/Muli-LightItalic-webfont.ttf') format('opentype'), url('../fonts/Muli-LightItalic-webfont.eot') format('embedded-opentype'), url('../fonts/Muli-LightItalic-webfont.svg') format('svg');
+    font-style: italic;
+    font-weight: 200;
+}
+
+
 .white {
     color: #fff
 }
@@ -197,6 +218,10 @@ ul.large li {
 
 .text-center {
     text-align: center
+}
+
+.font-weight-light {
+    font-weight: 200;
 }
 
 .inline, .list-horizontal li {

--- a/templates/Avent/year.html.twig
+++ b/templates/Avent/year.html.twig
@@ -11,6 +11,8 @@
     {{- "- calendrier de l'avent " ~ year -}}
 {% endblock %}
 
+{% block bodyid %}avent-{{ year }}{% endblock %}
+
 {% set header_extra %}
     <section class="presentation">
         <div class="container row">

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -24,7 +24,7 @@
             <link rel="alternate" type="application/atom+xml" title="AFSY - tous les articles" href="{{ url('feed_atom') }}"/>
         {% endblock %}
     </head>
-    <body id="{% block bodyid %}avent-{{ year }}{% endblock %}">
+    <body id="{% block bodyid 'blog' %}">
 
         {% include 'header.html.twig' %}
 


### PR DESCRIPTION
This PR adds a few CSS rules for better Markdown support. It includes:

- support for italic, light and light-italic variants of the main font
- new `.font-weight-light` class to use the light and light-italic variants
- centered images with a wider margin
- justified text for paragraphs and list items
- new class `.avent-image-legend` to be used on the `<p>` right after an image to have a clean image legend
- add a light padding to the main content to prevent text from touching the sides of the screen on mobile