### PR TITLE
🎨 Provide CSS for Blockquote tags

### DIFF
--- a/assets/css/avent.css
+++ b/assets/css/avent.css
@@ -29,3 +29,25 @@
     font-style: italic;
     color: #999;
 }
+
+.avent-article blockquote {
+    background-color: #dbdfe4;
+    position: relative;
+    padding: 1em 2em 1em 4em;
+    margin-top: 1em;
+}
+
+.avent-article blockquote:before {
+    content: "“";
+    position: absolute;
+    display: block;
+    font-size: 5em;
+    font-weight: bold;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 13px;
+}
+
+.avent-article blockquote p:first-child {
+    margin-top: 0;
+}


### PR DESCRIPTION
Blockquote don't have any style, so here is one:

![image](https://user-images.githubusercontent.com/225704/69920090-19d74b80-1484-11ea-8295-18aba0d3e012.png)

