### PR TITLE
Fix the rendering of article for day 8

### DIFF
--- a/templates/Avent/2019/day_08.html.twig
+++ b/templates/Avent/2019/day_08.html.twig
@@ -2,7 +2,7 @@
 
 {% set year = 2019 %}
 
-{% block article_title "REX : de Symfony 2 à Symfony 4 et au-delà<br/>(We are back !)" %}
+{% block article_title "REX : de Symfony 2 à Symfony 4 et au-delà (We are back !)" %}
 
 {% block article_content_md %}
 REX : de Symfony 2 à Symfony 4 et au-delà (We are back !)
@@ -155,11 +155,11 @@ Encore un gros chantier mais notre équipe en a l’habitude :)
 {% endblock %}
 
 {% block article_avatar %}
-    <img src="{{ asset('build/avent/2019/07/nicolas-demay-stephane-diagne.jpg') }}" alt="Nicolas Demay & Stéphane Diagne"/>
+    <img src="{{ asset('build/avent/2019/07/nicolas-demay-stephane-diagne.jpg') }}" alt="Nicolas Demay &amp; Stéphane Diagne"/>
 {% endblock %}
 
 {% block article_bio %}
-    <h2><a href="{% block author_url 'https://www.welcometothejungle.com/fr/companies/anaxago/jobs' %}">{% block article_author 'Nicolas Demay & Stéphane Diagne' %}</a></h2>
+    <h2><a href="{% block author_url 'https://www.welcometothejungle.com/fr/companies/anaxago/jobs' %}">{% block article_author 'Nicolas Demay &amp; Stéphane Diagne' %}</a></h2>
     <p>
         Développeurs à Anaxago
     </p>


### PR DESCRIPTION
`<br>` tag in the title is breaking the Atom feed, as it is not a valid tag in Atom.
And the escaping of `&` was missing in strings (literal strings are considered safe by the autoescaper).

Refs #202 