### PR TITLE
Render emojis in color on Ubuntu

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -5,7 +5,7 @@
 }
 
 body {
-    font-family: "Muli", "Helvetica", Arial, sans-serif;
+    font-family: "Muli", "Helvetica", Arial, emoji, sans-serif;
     background: #eaedf1;
     margin: 0 auto;
     font-size: 16px;


### PR DESCRIPTION
The Muli, Helvetica and Arial fonts don't support emoji chars. So their rendering fallbacks to `sans-serif`.
On most system, this works fine for emojis: the default sans-serif fonts don't support them and fallback to the system emoji font.
But on Ubuntu, the default sans-serif font is "DejaVu Sans", which actually provides emoji support, but using a black&white rendering.

CSS Fonts level 4 is adding a new special font family "emoji", which specifically targets emoji rendering. And on Ubuntu, "Noto Color Emoji" is preferred over "DejaVu Sans" for this family (when the font is installed, which is the default).

Preview: https://afsy.fr.pr-207-stkt3xy-esyx3y2kpl5ku.eu.s5y.io/avent/2019